### PR TITLE
Bumped urllib3 to 1.25

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 beckett==0.8.*      # main functionality
 fcache==0.4.*       # disk-based cache
-requests==2.21.*    # used by beckett (bumped to avoid CVE-2018-18074 and CVE-2019-11236)
+requests==2.21.*    # used by beckett (bumped to avoid CVE-2018-18074)
+urllib3==1.25       # used by requests (bumped to avoid CVE-2019-11236)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 beckett==0.8.*      # main functionality
 fcache==0.4.*       # disk-based cache
-requests==2.20.*    # used by beckett (bumped to avoid CVE-2018-18074)
+requests==2.21.*    # used by beckett (bumped to avoid CVE-2018-18074 and CVE-2019-11236)


### PR DESCRIPTION
because of CVE-2019-11236