### PR TITLE
Added a way to get encounters per Pokémon

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -40,6 +40,7 @@ The following is an exhaustive list of all the endpoints with links to their res
 * [get_item_pocket](https://pokeapi.co/docs/v2.html/#item-pockets)
 * [get_location](https://pokeapi.co/docs/v2.html/#locations)
 * [get_location_area](https://pokeapi.co/docs/v2.html/#location-areas)
+* [get_location_area_encounter](https://pokeapi.co/docs/v2.html/#pokemon)
 * [get_pal_park_area](https://pokeapi.co/docs/v2.html/#pal-park-areas)
 * [get_region](https://pokeapi.co/docs/v2.html/#regions)
 * [get_machine](https://pokeapi.co/docs/v2.html/#machines)

--- a/pokepy/api.py
+++ b/pokepy/api.py
@@ -74,7 +74,8 @@ class V2Client(BaseClient):
             rv2.PokemonSpeciesResource,
             rv2.StatResource,
             rv2.TypeResource,
-            rv2.LanguageResource
+            rv2.LanguageResource,
+            rv2.LocationAreaEncounterSubResource
         )
 
     def __init__(self, cache=None, cache_location=None, *args, **kwargs):
@@ -146,13 +147,19 @@ class V2Client(BaseClient):
             'valid_status_codes',
             DEFAULT_VALID_STATUS_CODES
         )
+        always_list = getattr(
+            resource_class.Meta,
+            'always_list',
+            False
+        )
 
         def extract_single_element_list(func):
             @functools.wraps(func)
             def inner(*args, **kwargs):
                 final = func(*args, **kwargs)
-                if isinstance(final, list) and len(final) == 1:
-                    final = final[0]
+                if not always_list:
+                    if isinstance(final, list) and len(final) == 1:
+                        final = final[0]
                 return final
             return inner
 

--- a/pokepy/resources_v2.py
+++ b/pokepy/resources_v2.py
@@ -852,7 +852,9 @@ class PokemonSpritesSubResource(SubResource):
 class LocationAreaEncounterSubResource(BaseResource):
     class Meta(BaseResource.Meta):
         name = 'Location_Area_Encounter'
+        resource_name = 'pokemon'
         identifier = 'location_area'
+        always_list = True
         subresources = {
             'location_area': NamedAPIResourceSubResource,
             'version_details': VersionEncounterDetailSubResource
@@ -860,6 +862,10 @@ class LocationAreaEncounterSubResource(BaseResource):
 
     def __repr__(self):
         return '<%s>' % self.Meta.name
+
+    @classmethod
+    def get_url(cls, url, uid, **kwargs):
+        return '%s/%s/encounters' % (url, uid)
 
 
 class PokemonFormSpritesSubResource(SubResource):


### PR DESCRIPTION
The function is called `get_location_area` to stay consistent with the API but this is a bit weird.
If it were up to me I'd swap `PokemonEncounter` and `LocationAreaEncounter` so the name matches the anchor point of the encounter and not the attributes inside. What do you think?

I also added a `always_list` attribute so it stills give a list even if there's only one encounter location. This might be rendered obsolete with a proper pagination implementation though.

**Note:** I couldn't test this on others versions of Python because `tox` was throwing an error I gave up trying to fix. Sorry about that.