### PR TITLE
Update PokemonSpeciesResource Attributes

### DIFF
--- a/pokepy/resources_v2.py
+++ b/pokepy/resources_v2.py
@@ -2113,6 +2113,8 @@ class PokemonSpeciesResource(BaseResource):
             'capture_rate',
             'base_happiness',
             'is_baby',
+            'is_legendary',
+            'is_mythical',
             'hatch_counter',
             'has_gender_differences',
             'forms_switchable',


### PR DESCRIPTION
Added `is_legendary` and `is_mythical` attributes in class `Meta` of `PokemonSpeciesResource`. I happened to be using this today like 2 mins ago and I found out that they were not included. The latest version of PokeAPI includes these keys in the JSON it returns.